### PR TITLE
feat: Workspace Upstream Crate Defaults

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,4 +32,4 @@ jobs:
         run: rustup toolchain install stable
 
       - name: 🧪 Test
-        run: cargo test --tests
+        run: cargo test --tests --workspace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,8 @@ repos:
       - id: fmt
       - id: check
       - id: clippy
+
+  - repo: https://github.com/est31/cargo-udeps
+    rev: v0.1.47
+    hooks:
+      - id: udeps

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,4 @@ repos:
     hooks:
       - id: fmt
       - id: check
-        args: ['--features', 'all']
       - id: clippy
-        args: ['--features', 'all']

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1968,11 +1968,6 @@ dependencies = [
 [[package]]
 name = "routers_shard"
 version = "0.1.0"
-dependencies = [
- "geo",
- "routers_codec",
- "scc",
-]
 
 [[package]]
 name = "routers_tiles"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,17 +264,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum-macros"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,7 +572,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
  "log",
- "regex",
 ]
 
 [[package]]
@@ -595,7 +583,6 @@ dependencies = [
  "anstream",
  "anstyle",
  "env_filter",
- "jiff",
  "log",
 ]
 
@@ -777,9 +764,9 @@ dependencies = [
 
 [[package]]
 name = "geo-traits"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b018fc19fa58202b03f1c809aebe654f7d70fd3887dace34c3d05c11aeb474b5"
+checksum = "2e7c353d12a704ccfab1ba8bfb1a7fe6cb18b665bf89d37f4f7890edcd260206"
 dependencies = [
  "geo-types",
 ]
@@ -1184,30 +1171,6 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
-name = "jiff"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02000660d30638906021176af16b17498bd0d12813dbfe7b276d8bc7f3c0806"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c30758ddd7188629c6713fc45d1188af4f44c90582311d0c8d8c9907f60c48"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
 
 [[package]]
 name = "js-sys"
@@ -1645,21 +1608,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "portable-atomic"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
-dependencies = [
- "portable-atomic",
-]
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1930,11 +1878,7 @@ name = "routers"
 version = "0.2.0"
 dependencies = [
  "approx",
- "axum 0.7.9",
- "axum-macros",
  "codspeed-criterion-compat",
- "fast_hilbert",
- "flate2",
  "geo",
  "indexmap 2.9.0",
  "itertools 0.14.0",
@@ -1951,8 +1895,6 @@ dependencies = [
  "rstar",
  "rustc-hash",
  "scc",
- "serde_qs",
- "tokio",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -2037,9 +1979,7 @@ name = "routers_tiles"
 version = "0.1.0"
 dependencies = [
  "axum 0.7.9",
- "axum-macros",
  "chrono",
- "env_logger",
  "fast_hilbert",
  "geo",
  "log",
@@ -2047,7 +1987,6 @@ dependencies = [
  "prost-build",
  "routers_geo",
  "serde",
- "serde_qs",
  "strum",
  "tracing",
 ]
@@ -2228,17 +2167,6 @@ checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
 dependencies = [
  "itoa",
  "serde",
-]
-
-[[package]]
-name = "serde_qs"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd34f36fe4c5ba9654417139a9b3a20d2e1de6012ee678ad14d240c22c78d8d6"
-dependencies = [
- "percent-encoding",
- "serde",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3127,9 +3055,9 @@ dependencies = [
 
 [[package]]
 name = "wkt"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c505a1a3f6ebda15c778ffa0317b583b10b2393a5506281132a2eef6880a691"
+checksum = "efb2b923ccc882312e559ffaa832a055ba9d1ac0cc8e86b3e25453247e4b81d7"
 dependencies = [
  "geo-traits",
  "geo-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,15 +94,11 @@ bench = false
 
 # === Root Dependencies ===
 [dependencies]
-# Fixtures
-fixtures = { workspace = true }
-
 # Logging Utility
 log = { workspace = true }
 
 # GeoRust
 geo = { workspace = true }
-wkt = { workspace = true }
 
 # Tracing [Optional-"tracing"]
 tracing = { workspace = true, optional = true }
@@ -130,6 +126,9 @@ measure_time = "0.9.0"
 rustc-hash = "2.1.1"
 
 [dev-dependencies]
+wkt = { workspace = true }
+fixtures = { workspace = true }
+
 criterion = { version = "2.10.1", features = ["async_tokio"], package = "codspeed-criterion-compat" }
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,4 @@
+# === Workspace ===
 [workspace]
 resolver = "2"
 members = [
@@ -8,115 +9,54 @@ members = [
 [workspace.lints.rust]
 unsafe_code = "forbid"
 
+# === Workspace Deps ===
 [workspace.dependencies]
+# Shared Fixtures
 fixtures = { version = "0.1.0", package = "routers_fixtures" }
 
-[patch.crates-io]
-routers_fixtures = { path = "libs/routers_fixtures" }
+# Optimisation Crates
+rayon = "1.10.0"
+scc = "2.3.4"
+itertools = "0.14.0"
+indexmap = "2.9.0"
 
-[package]
-name = "routers"
-description = "Rust-Based Routing Tooling for System-Agnostic Maps."
-readme = "README.md"
-version = "0.2.0"
-edition = "2024"
-license = "MIT"
-include = ["src/**/*", "readme.md"]
+# Logging
+log = { version = "0.4.22" }
+test-log = { version = "0.2.16", features = ["log"] }
 
-[lib]
-name = "routers"
-path = "src/lib.rs"
-bench = false
-
-[dependencies]
-fixtures = { workspace = true }
-codec = { path = "libs/routers_codec", package = "routers_codec", version = "0.1.0" }
-
-# Algorithm
-rstar = { version = "0.12.2", features = ["serde"] }
-petgraph = { version = "0.8.1", features = ["serde-1", "graphmap", "rayon"] }
-
-# Logging Utility
-log = { version = "0.4.22", features = [] }
-
+# Server/Paralellism
 tokio = { version = "1.41.1", features = [
     "rt",
     "rt-multi-thread",
     "macros",
     "fs",
-], optional = true }
+] }
 
-axum = { version = "0.7.7", features = ["query"], optional = true }
-axum-macros = { version = "0.4.1", optional = true }
-serde_qs = { version = "0.13.0", optional = true }
+# GeoRust
+geo = { version = "0.30.0" }
+wkt = { version = "0.14.0" }
+rstar = { version = "0.12.2", features = ["serde"] }
 
-# Tracing [Optional-"tracing"]
-tracing = { version = "0.1.40", optional = true }
+# Tracing
+tracing = { version = "0.1.40" }
 tracing-subscriber = { version = "0.3.18", features = [
     "tracing-log",
     "fmt",
     "env-filter",
-], optional = true }
-opentelemetry = { version = "0.26.0", optional = true }
+] }
+opentelemetry = { version = "0.26.0" }
 opentelemetry_sdk = { version = "0.26.0", features = [
     "rt-tokio",
-], optional = true }
-tracing-opentelemetry = { version = "0.27.0", optional = true }
-opentelemetry-otlp = { version = "0.26.0", features = ["tls"], optional = true }
+] }
+tracing-opentelemetry = { version = "0.27.0" }
+opentelemetry-otlp = { version = "0.26.0", features = ["tls"] }
 
-# Optimisations and Compression
-rayon = "1.10.0"
-flate2 = { version = "1.0.34", features = ["zlib-ng"], optional = true }
-fast_hilbert = { version = "2.0.0", optional = true }
-scc = { version = "2.2.4", optional = true }
-pathfinding = "4.14.0"
-approx = "0.5.1"
-itertools = "0.14.0"
-
-# GeoRust
-geo = "0.30.0"
-wkt = "0.13.0"
-measure_time = "0.9.0"
-rustc-hash = "2.1.1"
-indexmap = "2.9.0"
-
-[dev-dependencies]
+# Benchmarking
 criterion = { version = "2.10.1", features = [
     "async_tokio",
 ], package = "codspeed-criterion-compat" }
 
-[[bench]]
-name = "map_match"
-harness = false
-
-[[bench]]
-name = "total_ingestion"
-harness = false
-
-# TODO: Redo.
-[features]
-default = ["codec", "route"]
-
-tracing = [
-    "dep:tracing",
-    "tracing-subscriber",
-    "opentelemetry",
-    "opentelemetry_sdk",
-    "tracing-opentelemetry",
-    "opentelemetry-otlp",
-]
-
-http_server = ["axum", "axum-macros", "serde_qs", "tokio"]
-
-tile = ["http_server", "fast_hilbert"]
-route = ["scc", "codec"]
-codec = ["flate2"]
-
-all = ["tile", "route", "codec"]
-
-[package.metadata.docs.rs]
-features = ["tile", "route", "codec"]
-
+# === Profiles ===
 [profile.release]
 opt-level = 3
 lto = "fat"
@@ -132,3 +72,83 @@ lto = "off"
 
 [profile.dev.package."*"]
 opt-level = 3
+
+# === Patches ===
+[patch.crates-io]
+routers_fixtures = { path = "libs/routers_fixtures" }
+
+# === Root Package ===
+[package]
+name = "routers"
+description = "Rust-Based Routing Tooling for System-Agnostic Maps."
+readme = "README.md"
+version = "0.2.0"
+edition = "2024"
+license = "MIT"
+include = ["src/**/*", "readme.md"]
+
+[lib]
+name = "routers"
+path = "src/lib.rs"
+bench = false
+
+# === Root Dependencies ===
+[dependencies]
+# Fixtures
+fixtures = { workspace = true }
+
+# Logging Utility
+log = { workspace = true }
+
+# GeoRust
+geo = { workspace = true }
+wkt = { workspace = true }
+
+# Tracing [Optional-"tracing"]
+tracing = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, optional = true }
+opentelemetry = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
+tracing-opentelemetry = { workspace = true, optional = true }
+opentelemetry-otlp = { workspace = true, optional = true }
+
+# Optimisations and Compression
+rayon = { workspace = true }
+scc = { workspace = true }
+itertools = { workspace = true }
+indexmap = { workspace = true }
+
+# Algorithm
+rstar = { workspace = true }
+codec = { path = "libs/routers_codec", package = "routers_codec", version = "0.1.0" }
+petgraph = { version = "0.8.1", features = ["serde-1", "graphmap", "rayon"] }
+
+# Root-Specific Crates
+approx = "0.5.1"
+pathfinding = "4.14.0"
+measure_time = "0.9.0"
+rustc-hash = "2.1.1"
+
+[dev-dependencies]
+criterion = { version = "2.10.1", features = ["async_tokio"], package = "codspeed-criterion-compat" }
+
+[[bench]]
+name = "map_match"
+harness = false
+
+[[bench]]
+name = "total_ingestion"
+harness = false
+
+[features]
+tracing = [
+    "dep:tracing",
+    "tracing-subscriber",
+    "opentelemetry",
+    "opentelemetry_sdk",
+    "tracing-opentelemetry",
+    "opentelemetry-otlp",
+]
+
+[package.metadata.docs.rs]
+features = []

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 ### `routers`
 
+[![Test](https://github.com/bennjii/routers/actions/workflows/test.yml/badge.svg)](https://github.com/bennjii/routers/actions/workflows/test.yml)
+[![Format & Check](https://github.com/bennjii/routers/actions/workflows/format.yml/badge.svg)](https://github.com/bennjii/routers/actions/workflows/format.yml)
+[![Buf CI](https://github.com/bennjii/routers/actions/workflows/buf-ci.yml/badge.svg)](https://github.com/bennjii/routers/actions/workflows/buf-ci.yml)
+
+[![CodSpeed Badge](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json)](https://codspeed.io/bennjii/routers)
+
 Rust-Based Routing Tooling for System-Agnostic Maps.
 Supporting functionality such as Map-Matching, Tile Serving, Sharding, etc.

--- a/libs/routers_codec/Cargo.toml
+++ b/libs/routers_codec/Cargo.toml
@@ -29,13 +29,13 @@ rstar = { workspace = true }
 
 rayon = { workspace = true }
 log = { workspace = true }
-test-log = { workspace = true }
 
 # Tracing
 tracing = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 
 [dev-dependencies]
+test-log = { workspace = true }
 fixtures = { workspace = true }
 criterion = { workspace = true }
 

--- a/libs/routers_codec/Cargo.toml
+++ b/libs/routers_codec/Cargo.toml
@@ -13,39 +13,37 @@ path = "./src/lib.rs"
 bench = false
 
 [dependencies]
-# GeoRust
-geo = "0.30.0"
-rstar = { version = "0.12.2", features = ["serde"] }
-
+# TODO: Remove dependency.
 either = "1.13.0"
-rayon = "1.10.0"
 
 prost = { version = "0.13.3" }
 bytes = { version = "1.8.0", features = ["default"] } # Required for io::Cursor
+
+# Compression
 flate2 = { version = "1.1.1", features = ["zlib-rs"] }
-
-log = { version = "0.4.22", features = [] }
-test-log = { version = "0.2.16", features = ["log"] }
-
 mimalloc = { version = "0.1.43", optional = true }
 
-tracing = { version = "0.1.40", optional = true }
-tracing-subscriber = { version = "0.3.18", features = [
-    "tracing-log",
-    "fmt",
-    "env-filter",
-], optional = true }
+# GeoRust
+geo = { workspace = true }
+rstar = { workspace = true }
+
+rayon = { workspace = true }
+log = { workspace = true }
+test-log = { workspace = true }
+
+# Tracing
+tracing = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, optional = true }
 
 [dev-dependencies]
 fixtures = { workspace = true }
+criterion = { workspace = true }
 
-osmpbf = { version = "0.3.4", features = ["zlib-ng"], default-features = false }
-criterion = { version = "2.10.1", features = [
-    "async_tokio",
-], package = "codspeed-criterion-compat" }
+# Used to compare performance to ensure no large regression
+osmpbf = { version = "0.3.5", features = ["zlib-ng"], default-features = false }
 
 [build-dependencies]
-prost-build = { version = "0.13.3" }
+prost-build = { version = "0.13.5" }
 
 [[bench]]
 name = "codec_sweep"
@@ -57,4 +55,9 @@ harness = false
 
 [features]
 default = ["mimalloc"]
+
+# Alternate Allocator (Applies to #[global_allocator])
+mimalloc = ["dep:mimalloc"]
+
+# Tracing (For Debugging & Logging)
 tracing = ["dep:tracing", "dep:tracing-subscriber"]

--- a/libs/routers_codec/src/osm/element/test.rs
+++ b/libs/routers_codec/src/osm/element/test.rs
@@ -1,19 +1,19 @@
 #![cfg(test)]
 
-use fixtures::DISTRICT_OF_COLUMBIA;
+use fixtures::{DISTRICT_OF_COLUMBIA, fixture_path};
 
-use crate::element::item::Element;
-use crate::element::item::ProcessedElement;
-use crate::element::iterator::ElementIterator;
-use crate::element::processed_iterator::ProcessedElementIterator;
-use crate::parallel::Parallel;
+use crate::osm::element::item::Element;
+use crate::osm::element::item::ProcessedElement;
+use crate::osm::element::iterator::ElementIterator;
+use crate::osm::element::processed_iterator::ProcessedElementIterator;
+use crate::osm::parallel::Parallel;
+
 use log::info;
-use std::path::PathBuf;
 use std::time::Instant;
 
 #[test]
 fn try_into_iter() {
-    let path = PathBuf::from(DISTRICT_OF_COLUMBIA);
+    let path = fixture_path(DISTRICT_OF_COLUMBIA);
     let iter = ElementIterator::new(path).expect("Could not create iterator");
 
     iter.for_each(|item| {
@@ -23,7 +23,7 @@ fn try_into_iter() {
 
 #[test]
 fn iter_count() {
-    let path = PathBuf::from(DISTRICT_OF_COLUMBIA);
+    let path = fixture_path(DISTRICT_OF_COLUMBIA);
     let iter = ElementIterator::new(path).expect("Could not create iterator");
     let now = Instant::now();
 
@@ -44,7 +44,7 @@ fn iter_count() {
 
 #[test]
 fn processed_iter_count() {
-    let path = PathBuf::from(DISTRICT_OF_COLUMBIA);
+    let path = fixture_path(DISTRICT_OF_COLUMBIA);
     let iter = ProcessedElementIterator::new(path).expect("Could not create iterator");
 
     let now = Instant::now();

--- a/libs/routers_codec/src/osm/test.rs
+++ b/libs/routers_codec/src/osm/test.rs
@@ -1,18 +1,17 @@
 #![cfg(test)]
 
 use log::error;
-use std::path::PathBuf;
 use std::time::Instant;
 
-use crate::blob::iterator::BlobIterator;
-use crate::block::item::BlockItem;
-use crate::block::iterator::BlockIterator;
-use fixtures::{BADEN_WUERTTEMBERG, DISTRICT_OF_COLUMBIA};
+use crate::osm::blob::iterator::BlobIterator;
+use crate::osm::block::item::BlockItem;
+use crate::osm::block::iterator::BlockIterator;
+use fixtures::{BADEN_WUERTTEMBERG, DISTRICT_OF_COLUMBIA, fixture_path};
 use rayon::iter::{ParallelBridge, ParallelIterator};
 
 #[test]
 fn iterate_blobs_each() {
-    let path = PathBuf::from(BADEN_WUERTTEMBERG);
+    let path = fixture_path(BADEN_WUERTTEMBERG);
     let iterator = BlobIterator::new(path.clone());
 
     let now = Instant::now();
@@ -43,7 +42,7 @@ fn iterate_blobs_each() {
 
 #[test_log::test]
 fn iterate_blocks_each() {
-    let path = PathBuf::from(DISTRICT_OF_COLUMBIA);
+    let path = fixture_path(DISTRICT_OF_COLUMBIA);
     let iterator = BlockIterator::new(path.clone());
 
     let mut primitive_blocks = 0;
@@ -72,7 +71,7 @@ fn iterate_blocks_each() {
 
 #[test_log::test]
 fn parallel_iterate_blocks_each() {
-    let path = PathBuf::from(DISTRICT_OF_COLUMBIA);
+    let path = fixture_path(DISTRICT_OF_COLUMBIA);
 
     let block_iter = BlockIterator::new(path).unwrap();
 

--- a/libs/routers_grpc/Cargo.toml
+++ b/libs/routers_grpc/Cargo.toml
@@ -9,12 +9,7 @@ path = "src/lib.rs"
 bench = false
 
 [dependencies]
-# Workspace Crates
-fixtures = { workspace = true }
 routers = { path = "../.." }
-
-# Environment Variable Resolution
-dotenv = "0.15.0"
 
 # Protobuf Handling
 prost = { version = "0.13.3" }
@@ -22,11 +17,6 @@ prost-types = "0.13.4"
 
 # gRPC Server Dependencies
 tonic = { version = "0.13.1", features = [] }
-tonic-reflection = { version = "0.13.1" }
-tonic-web = { version = "0.13.1" }
-
-# HTTP Server Dependencies
-tower-http = { version = "0.6.1", features = ["cors"] }
 
 # GeoRust
 geo = { workspace = true }
@@ -37,13 +27,26 @@ tokio = { workspace = true }
 
 # Tracing
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
-tracing-opentelemetry = { workspace = true }
 
 # OpenTelemetry
 opentelemetry = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
+
+tracing-subscriber = { workspace = true, optional = true }
+tracing-opentelemetry = { workspace = true, optional = true }
+
+[dev-dependencies]
+# Environment Variable Resolution
+dotenv = "0.15.0"
+
+# Workspace Crates
+fixtures = { workspace = true }
+
+# Server Example
+tower-http = { version = "0.6.1", features = ["cors"] }
+tonic-reflection = { version = "0.13.1" }
+tonic-web = { version = "0.13.1" }
 
 [build-dependencies]
 tonic-build = { version = "0.13.0", features = ["prost"] }
@@ -55,7 +58,10 @@ default = []
 telemetry = [
     "dep:opentelemetry",
     "dep:opentelemetry_sdk",
-    "dep:opentelemetry-otlp"
+    "dep:opentelemetry-otlp",
+
+    "dep:tracing-subscriber",
+    "dep:tracing-opentelemetry"
 ]
 
 [[example]]

--- a/libs/routers_grpc/Cargo.toml
+++ b/libs/routers_grpc/Cargo.toml
@@ -9,49 +9,41 @@ path = "src/lib.rs"
 bench = false
 
 [dependencies]
+# Workspace Crates
 fixtures = { workspace = true }
-
 routers = { path = "../.." }
 
-geo = "0.30.0"
-wkt = "0.13.0"
-log = { version = "0.4.22", features = [] }
-
-tokio = { version = "1.41.1", features = [
-    "rt",
-    "rt-multi-thread",
-    "macros",
-    "fs",
-]}
-
+# Environment Variable Resolution
 dotenv = "0.15.0"
 
+# Protobuf Handling
 prost = { version = "0.13.3" }
 prost-types = "0.13.4"
 
 # gRPC Server Dependencies
-tonic = { version = "0.13.0", features = [] }
-tonic-reflection = { version = "0.13.0" }
-tonic-web = { version = "0.13.0" }
+tonic = { version = "0.13.1", features = [] }
+tonic-reflection = { version = "0.13.1" }
+tonic-web = { version = "0.13.1" }
 
 # HTTP Server Dependencies
 tower-http = { version = "0.6.1", features = ["cors"] }
 
-# Tracing
-tracing = { version = "0.1.40" }
-tracing-subscriber = { version = "0.3.18", features = [
-    "tracing-log",
-    "fmt",
-    "env-filter",
-] }
-tracing-opentelemetry = { version = "0.27.0" }
+# GeoRust
+geo = { workspace = true }
+wkt = { workspace = true }
 
-# Open-Telemetry Modules
-opentelemetry = { version = "0.26.0", optional = true }
-opentelemetry_sdk = { version = "0.26.0", features = [
-    "rt-tokio",
-], optional = true }
-opentelemetry-otlp = { version = "0.26.0", features = ["tls"], optional = true }
+log = { workspace = true }
+tokio = { workspace = true }
+
+# Tracing
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+tracing-opentelemetry = { workspace = true }
+
+# OpenTelemetry
+opentelemetry = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
+opentelemetry-otlp = { workspace = true, optional = true }
 
 [build-dependencies]
 tonic-build = { version = "0.13.0", features = ["prost"] }
@@ -60,7 +52,7 @@ walkdir = "2.5.0"
 
 [features]
 default = []
-tracing = [
+telemetry = [
     "dep:opentelemetry",
     "dep:opentelemetry_sdk",
     "dep:opentelemetry-otlp"
@@ -74,3 +66,6 @@ path = "examples/client.rs"
 name = "server"
 path = "examples/server.rs"
 required-features = ["tracing"]
+
+[lints]
+workspace = true

--- a/libs/routers_grpc/src/lib.rs
+++ b/libs/routers_grpc/src/lib.rs
@@ -3,8 +3,8 @@ pub mod services;
 pub mod definition;
 pub use definition::*;
 
-#[cfg(feature = "tracing")]
+#[cfg(feature = "telemetry")]
 pub mod trace;
 
-#[cfg(feature = "tracing")]
+#[cfg(feature = "telemetry")]
 pub use trace::*;

--- a/libs/routers_grpc/src/services/matcher.rs
+++ b/libs/routers_grpc/src/services/matcher.rs
@@ -6,12 +6,12 @@ use crate::definition::r#match::*;
 use crate::definition::model::*;
 
 use crate::services::RouteService;
-#[cfg(feature = "tracing")]
+#[cfg(feature = "telemetry")]
 use tracing::Level;
 
 #[tonic::async_trait]
 impl MatchService for Arc<RouteService> {
-    #[cfg_attr(feature="tracing", tracing::instrument(skip_all, level = Level::INFO))]
+    #[cfg_attr(feature="telemetry", tracing::instrument(skip_all, level = Level::INFO))]
     async fn r#match(
         self: Arc<Self>,
         request: Request<MatchRequest>,
@@ -64,6 +64,7 @@ impl MatchService for Arc<RouteService> {
         }))
     }
 
+    #[cfg_attr(feature="telemetry", tracing::instrument(skip_all, level = Level::INFO))]
     async fn snap(
         self: Arc<Self>,
         _request: Request<SnapRequest>,

--- a/libs/routers_grpc/src/services/optimise.rs
+++ b/libs/routers_grpc/src/services/optimise.rs
@@ -6,12 +6,12 @@ use crate::definition::model::*;
 use crate::definition::optimise::*;
 
 use crate::services::RouteService;
-#[cfg(feature = "tracing")]
+#[cfg(feature = "telemetry")]
 use tracing::Level;
 
 #[tonic::async_trait]
 impl OptimisationService for Arc<RouteService> {
-    #[cfg_attr(feature="tracing", tracing::instrument(skip_all, err(level = Level::INFO)))]
+    #[cfg_attr(feature="telemetry", tracing::instrument(skip_all, err(level = Level::INFO)))]
     async fn route(
         self: Arc<Self>,
         request: Request<RouteRequest>,

--- a/libs/routers_grpc/src/services/proximity.rs
+++ b/libs/routers_grpc/src/services/proximity.rs
@@ -9,13 +9,13 @@ use crate::definition::proximity::*;
 
 use crate::services::RouteService;
 use routers::Scan;
-#[cfg(feature = "tracing")]
+#[cfg(feature = "telemetry")]
 use tracing::Level;
 use wkt::ToWkt;
 
 #[tonic::async_trait]
 impl ProximityService for Arc<RouteService> {
-    #[cfg_attr(feature="tracing", tracing::instrument(skip_all, err(level = Level::INFO)))]
+    #[cfg_attr(feature="telemetry", tracing::instrument(skip_all, err(level = Level::INFO)))]
     async fn closest_point(
         self: Arc<Self>,
         request: Request<ClosestPointRequest>,
@@ -41,7 +41,7 @@ impl ProximityService for Arc<RouteService> {
         }))
     }
 
-    #[cfg_attr(feature="tracing", tracing::instrument(skip_all, err(level = Level::INFO)))]
+    #[cfg_attr(feature="telemetry", tracing::instrument(skip_all, err(level = Level::INFO)))]
     async fn closest_snapped_point(
         self: Arc<Self>,
         request: Request<ClosestSnappedPointRequest>,

--- a/libs/routers_shard/Cargo.toml
+++ b/libs/routers_shard/Cargo.toml
@@ -4,8 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-geo = "0.30.0"
 
-routers_codec = { path = "../routers_codec" }
-
-scc = { version = "2.2.4" }
+[lints]
+workspace = true

--- a/libs/routers_tiles/Cargo.toml
+++ b/libs/routers_tiles/Cargo.toml
@@ -9,15 +9,10 @@ routers_geo = { path = "../routers_geo" }
 
 # Server dependencies
 axum = { version = "0.7.7", features = ["query"] }
-axum-macros = { version = "0.4.1" }
-serde_qs = { version = "0.13.0" }
+prost = { version = "0.13.3" }
 
 fast_hilbert = { version = "2.0.0" }
-
 strum = { version = "0.26.3", features = ["phf", "derive"] }
-env_logger = "0.11.5"
-
-prost = { version = "0.13.3" }
 
 chrono = "0.4.38"
 log = { version = "0.4.22", features = [] }


### PR DESCRIPTION
Assigns the workspace as the source of truth for member dependencies, ensuring systems run on a minimal number of fragmented versions.

Adds all workspace tests to CI, and removes unnecessary dependencies, adding `cargo-udeps` to the pre-commit hook.